### PR TITLE
Add CONTRIBUTING.md file which points to the faas contrib guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+## Contributing
+
+Please follow the [contribution guide for OpenFaaS](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
Adding CONTRIBUTING.md file

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>