### PR TITLE
Add reconcile_interval environmental variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Try using the ClusterIP/Cluster Service instead and port 8080.
 `prometheus_host` - host for Prometheus
 `prometheus_port` - port for Prometheus
 `inactivity_duration` - i.e. `10m` (Golang duration)
+`reconcile_interval` - i.e. `30s` (default value)
 
-The `reconcileInterval` is hard-coded to run every 30s.
 
 * Command-line args
 

--- a/faas-idler-dep.yml
+++ b/faas-idler-dep.yml
@@ -23,6 +23,8 @@ spec:
             value: "9090"
           - name: inactivity_duration
             value: "5m"
+          - name: reconcile_interval
+            value: "30s"
         command:
           - /home/app/faas-idler
           - -dry-run=true

--- a/main.go
+++ b/main.go
@@ -25,7 +25,15 @@ func main() {
 	flag.BoolVar(&dryRun, "dry-run", false, "use dry-run for scaling events")
 	flag.Parse()
 
-	reconcileInterval := time.Second * 30
+	frequency, freqExist := os.LookupEnv("reconcile_interval")
+	if freqExist == false {
+		frequency = "30s"
+	}
+
+	reconcileInterval, intervalErr := time.ParseDuration(frequency)
+	if intervalErr != nil {
+		log.Println(intervalErr)
+	}
 
 	client := &http.Client{}
 	gatewayURL := os.Getenv("gateway_url")


### PR DESCRIPTION
Adding reconcile_interval environmental variable to
configure the frequency

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

Closes #5 