### PR TITLE
Enable idler to pass basic auth credentials

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2018 Alex Ellis
+Copyright (c) 2018 OpenFaaS Author(s)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,6 @@ TAG?=latest-dev
 .PHONY: build
 
 build:
-	docker build -t alexellis/faas-idler:${TAG} .
+	docker build -t openfaas/faas-idler:${TAG} .
 push:
-	docker push alexellis/faas-idler:${TAG}
+	docker push openfaas/faas-idler:${TAG}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
             prometheus_host: "prometheus"
             prometheus_port: "9090"
             inactivity_duration: "5m"
+            reconcile_interval: "30s"
         command: "-dry-run=true"
         deploy:
             resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
     faas-idler:
-        image: openfaas/faas-idler:0.1.4
+        image: openfaas/faas-idler:0.1.5
         networks:
             - func_functions
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
     faas-idler:
-        image: openfaas/faas-idler:0.1.3
+        image: openfaas/faas-idler:0.1.4
         networks:
             - func_functions
         environment:
@@ -9,7 +9,7 @@ services:
             prometheus_host: "prometheus"
             prometheus_port: "9090"
             inactivity_duration: "5m"
-        command: "-dry-run=true"
+        command: "-dry-run=false"
         deploy:
             resources:
                 limits:   # Enable if you want to limit memory usage
@@ -25,6 +25,16 @@ services:
                 constraints:
                     - 'node.platform.os == linux'
                     - 'node.role == manager'
+        secrets:
+            - basic-auth-user
+            - basic-auth-password
+
 networks:
     func_functions:
+        external: true
+
+secrets:
+    basic-auth-user:
+        external: true
+    basic-auth-password:
         external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
     faas-idler:
-        image: alexellis/faas-idler:0.1.2
+        image: openfaas/faas-idler:0.1.3
         networks:
             - func_functions
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
     faas-idler:
-        image: openfaas/faas-idler:0.1.5
+        image: openfaas/faas-idler:0.1.6
         networks:
             - func_functions
         environment:
@@ -27,8 +27,10 @@ services:
                     - 'node.platform.os == linux'
                     - 'node.role == manager'
         secrets:
-            - basic-auth-user
-            - basic-auth-password
+            - source: basic-auth-user
+              target: /var/secrets/basic-auth-user
+            - source: basic-auth-password
+              target: /var/secrets/basic-auth-password
 
 networks:
     func_functions:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
             prometheus_host: "prometheus"
             prometheus_port: "9090"
             inactivity_duration: "5m"
-        command: "-dry-run=false"
+        command: "-dry-run=true"
         deploy:
             resources:
                 limits:   # Enable if you want to limit memory usage

--- a/faas-idler-dep.yml
+++ b/faas-idler-dep.yml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: faas-idler
-        image: openfaas/faas-idler:0.1.3
+        image: openfaas/faas-idler:0.1.4
         imagePullPolicy: Always
         env:
           - name: gateway_url
@@ -28,3 +28,11 @@ spec:
         command:
           - /home/app/faas-idler
           - -dry-run=true
+        volumeMounts:
+        - name: auth
+          readOnly: true
+          mountPath: "/run/secrets/"
+      volumes:
+      - name: auth
+        secret:
+          secretName: basic-auth

--- a/faas-idler-dep.yml
+++ b/faas-idler-dep.yml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: faas-idler
-        image: openfaas/faas-idler:0.1.5
+        image: openfaas/faas-idler:0.1.6
         imagePullPolicy: Always
         env:
           - name: gateway_url
@@ -31,7 +31,7 @@ spec:
         volumeMounts:
         - name: auth
           readOnly: true
-          mountPath: "/run/secrets/"
+          mountPath: "/var/secrets/"
       volumes:
       - name: auth
         secret:

--- a/faas-idler-dep.yml
+++ b/faas-idler-dep.yml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: faas-idler
-        image: openfaas/faas-idler:0.1.4
+        image: openfaas/faas-idler:0.1.5
         imagePullPolicy: Always
         env:
           - name: gateway_url

--- a/main.go
+++ b/main.go
@@ -53,14 +53,14 @@ func main() {
 		log.Panic("env-var prometheus_host must be set")
 	}
 
-	val, err := readFile("/run/secrets/basic-auth-user")
+	val, err := readFile("/var/secrets/basic-auth-user")
 	if err == nil {
 		credentials.Username = val
 	} else {
 		log.Printf("Unable to read username: %s", err)
 	}
 
-	passwordVal, passErr := readFile("/run/secrets/basic-auth-password")
+	passwordVal, passErr := readFile("/var/secrets/basic-auth-password")
 	if passErr == nil {
 		credentials.Password = passwordVal
 	} else {

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func main() {
 		panic(err)
 	}
 
-	log.Printf("Gateway version: %s\n", version.Release)
+	log.Printf("Gateway version: %s, SHA: %s\n", version.Version.Release, version.Version.SHA)
 
 	prometheusHost := os.Getenv("prometheus_host")
 
@@ -270,7 +270,10 @@ func sendScaleEvent(client *http.Client, gatewayURL string, name string, replica
 }
 
 type Version struct {
-	Release string
+	Version struct {
+		Release string `json:"release"`
+		SHA     string `json:"sha"`
+	}
 }
 
 func getVersion(client *http.Client, gatewayURL string, credentials *Credentials) (Version, error) {


### PR DESCRIPTION
## Description

Enables idler to pass basic auth credentials to the gateway on Swarm / K8s

Fixes #4 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on Swarm end-to-end and without auth enabled.

## Checklist:

I have:

- [ ] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

