### PR TITLE
Run build during CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+sudo: required
+
+services:
+  - docker
+
+addons:
+  apt:
+    packages:
+      - docker-ce
+
+script:
+  - make build
+
+after_success:
+    - if [ -z $DOCKER_NS ] ; then
+        export DOCKER_NS=openfaas;
+        fi
+
+    - if [ ! -z "$TRAVIS_TAG" ] ; then 
+        docker tag $DOCKER_NS/faas-idler:latest $DOCKER_NS/faas-idler:$TRAVIS_TAG;
+        echo $DOCKER_PASSWORD | docker login -u=$DOCKER_USERNAME --password-stdin;
+        docker push $DOCKER_NS/faas-idler:$TRAVIS_TAG;
+
+        docker tag $DOCKER_NS/faas-idler:latest quay.io/$DOCKER_NS/faas-idler:$TRAVIS_TAG;
+        echo $QUAY_PASSWORD | docker login -u=$QUAY_USERNAME --password-stdin quay.io;
+        docker push quay.io/$DOCKER_NS/faas-idler:$TRAVIS_TAG;
+
+        fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
             prometheus_host: "prometheus"
             prometheus_port: "9090"
             inactivity_duration: "5m"
+            reconcile_interval: "30s"
         command: "-dry-run=true"
         deploy:
             resources:


### PR DESCRIPTION
With this change an automated build is configured to run with
Travis to validate code changes and pull requests. After build
Docker image is going to be pushed to both Docker Hub and Quay.io.
Namespace is moved to `openfaas` in docker-compose.yml and
Makefile

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

Resolves #2 
