### PR TITLE
Secret mount path env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.out
 
 faas-idler
+basic-auth-*

--- a/README.md
+++ b/README.md
@@ -51,12 +51,16 @@ On Kubernetes the `gateway_url` needs to contain the suffix of the namespace you
 
 Try using the ClusterIP/Cluster Service instead and port 8080.
 
-`gateway_url` - URL for faas-provider
-`prometheus_host` - host for Prometheus
-`prometheus_port` - port for Prometheus
-`inactivity_duration` - i.e. `10m` (Golang duration)
-`reconcile_interval` - i.e. `30s` (default value)
-`write_debug` - default `false`, set to `true` to enable verbose logging for debugging / troubleshooting
+| env_var               | description                                                 |
+| --------------------- |----------------------------------------------------------   |
+| `gateway_url`         | The URL for the API gateway i.e. http://gateway:8080 or http://gateway.openfaas:8080 for Kubernetes       |
+| `prometheus_host`     | host for Prometheus |
+| `prometheus_port`     | port for Prometheus |
+| `inactivity_duration` | i.e. `10m` (Golang duration) |
+| `reconcile_interval`  | i.e. `30s` (default value) |
+| `secret_mount_path`   | default `/var/secrets/`, path from which `basic-auth-user` and `basic-auth-password` files are read |
+| `write_debug`         | default `false`, set to `true` to enable verbose logging for debugging / troubleshooting |
+
 
 * Command-line args
 

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -48,16 +49,19 @@ func main() {
 
 	credentials := Credentials{}
 
-	val, err := readFile("/var/secrets/basic-auth-user")
-	if err == nil {
+	secretMountPath := "/var/secrets/"
+	if val, ok := os.LookupEnv("secret_mount_path"); ok && len(val) > 0 {
+		secretMountPath = val
+	}
+
+	if val, err := readFile(path.Join(secretMountPath, "basic-auth-user")); err == nil {
 		credentials.Username = val
 	} else {
 		log.Printf("Unable to read username: %s", err)
 	}
 
-	passwordVal, passErr := readFile("/var/secrets/basic-auth-password")
-	if passErr == nil {
-		credentials.Password = passwordVal
+	if val, err := readFile(path.Join(secretMountPath, "basic-auth-password")); err == nil {
+		credentials.Password = val
 	} else {
 		log.Printf("Unable to read password: %s", err)
 	}


### PR DESCRIPTION
## Description

`/var/secrets` mount path can be overriden using environment variable `secret_mount_path`

Updated README with `secret_mount_path` env variable and formatted the env variables documentation with a table according to kafka-connector's README

## How Has This Been Tested?

Tested the env setup using the following command line :

secret_mount_path=$(PWD) \
gateway_url=http://localhost:8080/ \
prometheus_host=localhost prometheus_port=9090 \
inactivity_duration=1m \
reconcile_interval=30s \
faas-idler

Made sure user and password are still properly read from secrets when deployed in Kubernetes without setting the secret_mount_path env variable.

## Checklist:

I have:

- [x] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

